### PR TITLE
Add option to set initial window size

### DIFF
--- a/autoload/ags/buf.vim
+++ b/autoload/ags/buf.vim
@@ -26,7 +26,8 @@ let s:cmd = {
 "
 function! s:openWin(name, cmd)
     let bufcmd = a:cmd == 'same' ? 'buffer ' : a:cmd . ' sbuffer '
-    let wincmd = a:cmd == 'same' ? 'edit '   : a:cmd . ' new '
+    let winsize  = has_key(g:, 'ags_winsize') ? g:ags_winsize : ''
+    let wincmd = a:cmd == 'same' ? 'edit '   : a:cmd . ' ' . winsize . 'new '
 
     if bufexists(a:name)
         let nr = bufwinnr(a:name)


### PR DESCRIPTION
Not sure if there's a better way to do this, but I was coming from vim-ag which uses the quickfix window that's a lot smaller than half the current window `new` uses by default. This adds an optional size argument to `new` so new search results windows don't take up half the screen.

Go easy on me...I'm definitely not a vimscripter ;)
